### PR TITLE
Add watcher script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "make-spec": ". ./scripts/network-spec && cd ./pos-contracts && npm i && node ./scripts/make_spec.js",
     "start-test-setup": "bash scripts/start-test-setup ../parity-ethereum/target/debug/parity",
     "test": "sleep inf",
-    "stop-test-setup": "bash scripts/stop-test-setup"
+    "stop-test-setup": "bash scripts/stop-test-setup",
+    "watcher": "node scripts/watcher.js"
   },
   "repository": {
     "type": "git",
@@ -19,6 +20,7 @@
   "author": "poa.network",
   "license": "ISC",
   "dependencies": {
-    "sha3": "^2.0.0"
+    "sha3": "^2.0.0",
+    "web3": "1.0.0-beta.34"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   "license": "ISC",
   "dependencies": {
     "sha3": "^2.0.0",
-    "web3": "1.0.0-beta.34"
+    "web3": "1.0.0-beta.37"
   }
 }

--- a/scripts/watcher.js
+++ b/scripts/watcher.js
@@ -1,0 +1,128 @@
+console.log('');
+console.log('');
+
+const fs = require('fs');
+const Web3 = require('web3');
+const web3 = new Web3(new Web3.providers.WebsocketProvider('ws://localhost:9541'));
+
+const artifactsPath = '../pos-contracts/build/contracts/';
+const validatorSetContract = new web3.eth.Contract(
+  require(`${artifactsPath}ValidatorSetAuRa.json`).abi,
+  '0x1000000000000000000000000000000000000001'
+);
+const randomContract = new web3.eth.Contract(
+  require(`${artifactsPath}RandomAuRa.json`).abi,
+  '0x3000000000000000000000000000000000000001'
+);
+
+const contractNameByAddress = {};
+contractNameByAddress[validatorSetContract.options.address] = 'ValidatorSetAuRa';
+contractNameByAddress[randomContract.options.address] = 'RandomAuRa';
+
+web3.eth.subscribe('newBlockHeaders', function(error, result){
+  if (error) {
+    console.log(error);
+  }
+}).on("data", async function(blockHeader){
+  if (blockHeader.number) {
+    const block = await web3.eth.getBlock(blockHeader.number, true);
+
+    console.log(`Block ${blockHeader.number}`);
+    console.log(`  Gas used:  ${blockHeader.gasUsed} [${block.transactions.length} txs]`);
+    console.log(`  Validator: ${blockHeader.miner}`);
+    console.log('');
+
+    const stakingEpoch = await validatorSetContract.methods.stakingEpoch().call();
+    const stakingEpochStartBlock = await validatorSetContract.methods.stakingEpochStartBlock().call();
+    const validatorSetApplyBlock = await validatorSetContract.methods.validatorSetApplyBlock().call();
+    console.log(`stakingEpoch ${stakingEpoch}`);
+    console.log(`  startBlock ${stakingEpochStartBlock}`);
+    console.log(`  applyBlock ${validatorSetApplyBlock > 0 ? validatorSetApplyBlock : '-'}`);
+    console.log('');
+
+    const collectionRound = await randomContract.methods.currentCollectRound().call();
+    const isCommitPhase = await randomContract.methods.isCommitPhase().call();
+    console.log(`collectionRound ${collectionRound}`);
+    console.log(`  ${isCommitPhase ? 'COMMITS' : 'REVEALS'} PHASE`);
+    console.log('');
+
+    let emptyList = true;
+    let method;
+    const validators = await validatorSetContract.methods.getValidators().call();
+
+    if (isCommitPhase) {
+      console.log('isCommitted:');
+      method = randomContract.methods.isCommitted;
+    } else {
+      console.log('sentReveal:');
+      method = randomContract.methods.sentReveal;
+    }
+    for (let i = 0; i < validators.length; i++) {
+      const result = await method(collectionRound, validators[i]).call();
+      if (result) {
+        console.log(`  ${validators[i]}`);
+        emptyList = false;
+      }
+    }
+    if (emptyList) {
+      console.log('-');
+    }
+    console.log('');
+
+    //console.log('currentRandom:');
+    //console.log(await randomContract.methods.currentRandom().call());
+    //console.log('');
+
+    const events = await validatorSetContract.getPastEvents('InitiateChange', {fromBlock: blockHeader.number, toBlock: blockHeader.number});
+    for (let i = 0; i < events.length; i++) {
+      console.log('InitiateChange:');
+      console.log(events[i].returnValues.newSet);
+      console.log('');
+    }
+
+    let txSuccess = [];
+    let txFail = [];
+
+    for (let i = 0; i < block.transactions.length; i++) {
+      const tx = block.transactions[i];
+      const txReceipt = await web3.eth.getTransactionReceipt(tx.hash);
+      const txObject = {from: tx.from, to: tx.to, receipt: txReceipt};
+      if (txReceipt.status) {
+        txSuccess.push(txObject);
+      } else {
+        txFail.push(txObject);
+      }
+    }
+
+    if (txSuccess.length > 0) {
+      console.log('SUCCESS transactions:');
+      txSuccess.forEach((tx) => {
+        let contractName = 'unknown';
+        if (contractNameByAddress.hasOwnProperty(tx.to)) {
+          contractName = contractNameByAddress[tx.to]
+        }
+        console.log(`  ${tx.from} => ${contractName}`);
+        console.log(`    gas used: ${tx.receipt.gasUsed}`);
+      });
+      console.log('');
+    }
+
+    if (txFail.length > 0) {
+      console.log('FAILED transactions:');
+      txFail.forEach((tx) => {
+        let contractName = 'unknown';
+        if (contractNameByAddress.hasOwnProperty(tx.to)) {
+          contractName = contractNameByAddress[tx.to]
+        }
+        console.log(`  ${tx.from} => ${contractName}`);
+        console.log(`    gas used: ${tx.receipt.gasUsed}`);
+      });
+      console.log('');
+    }
+
+    console.log('');
+    console.log('=======================================================');
+    console.log('');
+    console.log('');
+  }
+}).on("error", console.error);


### PR DESCRIPTION
I've added `scripts/watcher.js` which helps to see what happens on each block after `npm run start-test-setup` is performed. The script displays the next info for each new block:
- who is block's producer
- the current number of staking epoch
- the number of block at which current staking epoch started
- the number of block at which the current validator set was applied by engine
- current collection round number
- the current phase (commit or reveal)
- which validators committed/ revealed during the current collection round
- success and failed transactions included in the block

Usage:
```bash
$ npm run watcher
```