### PR TITLE
Set nat variable to none in .toml configs

### DIFF
--- a/config/node1.toml
+++ b/config/node1.toml
@@ -7,6 +7,7 @@ disable = true
 
 [network]
 port = 30301
+nat = "none"
 
 [rpc]
 apis = ["web3", "eth", "pubsub", "net", "parity", "parity_set", "parity_pubsub", "personal", "traces", "rpc", "shh", "shh_pubsub"]

--- a/config/node2.toml
+++ b/config/node2.toml
@@ -9,6 +9,7 @@ disable = true
 port = 30302
 discovery = true
 reserved_peers="parity-data/reserved-peers"
+nat = "none"
 
 [rpc]
 apis = ["web3", "eth", "pubsub", "net", "parity", "parity_set", "parity_pubsub", "personal", "traces", "rpc", "shh", "shh_pubsub"]

--- a/config/node3.toml
+++ b/config/node3.toml
@@ -9,6 +9,7 @@ disable = true
 port = 30303
 discovery = true
 reserved_peers="parity-data/reserved-peers"
+nat = "none"
 
 [rpc]
 apis = ["web3", "eth", "pubsub", "net", "parity", "parity_set", "parity_pubsub", "personal", "traces", "rpc", "shh", "shh_pubsub"]

--- a/config/node4.toml
+++ b/config/node4.toml
@@ -7,6 +7,7 @@ disable = true
 
 [network]
 port = 30304
+nat = "none"
 
 [rpc]
 apis = ["web3", "eth", "pubsub", "net", "parity", "parity_set", "parity_pubsub", "personal", "traces", "rpc", "shh", "shh_pubsub"]

--- a/config/node5.toml
+++ b/config/node5.toml
@@ -9,6 +9,7 @@ disable = true
 port = 30305
 discovery = true
 reserved_peers="parity-data/reserved-peers"
+nat = "none"
 
 [rpc]
 apis = ["web3", "eth", "pubsub", "net", "parity", "parity_set", "parity_pubsub", "personal", "traces", "rpc", "shh", "shh_pubsub"]

--- a/config/node6.toml
+++ b/config/node6.toml
@@ -9,6 +9,7 @@ disable = true
 port = 30306
 discovery = true
 reserved_peers="parity-data/reserved-peers"
+nat = "none"
 
 [rpc]
 apis = ["web3", "eth", "pubsub", "net", "parity", "parity_set", "parity_pubsub", "personal", "traces", "rpc", "shh", "shh_pubsub"]

--- a/config/node7.toml
+++ b/config/node7.toml
@@ -9,6 +9,7 @@ disable = true
 port = 30307
 discovery = true
 reserved_peers="parity-data/reserved-peers"
+nat = "none"
 
 [rpc]
 apis = ["web3", "eth", "pubsub", "net", "parity", "parity_set", "parity_pubsub", "personal", "traces", "rpc", "shh", "shh_pubsub"]

--- a/config/node8.toml
+++ b/config/node8.toml
@@ -9,6 +9,7 @@ disable = true
 port = 30308
 discovery = true
 reserved_peers="parity-data/reserved-peers"
+nat = "none"
 
 [rpc]
 apis = ["web3", "eth", "pubsub", "net", "parity", "parity_set", "parity_pubsub", "personal", "traces", "rpc", "shh", "shh_pubsub"]

--- a/config/node9.toml
+++ b/config/node9.toml
@@ -9,6 +9,7 @@ disable = true
 port = 30309
 discovery = true
 reserved_peers="parity-data/reserved-peers"
+nat = "none"
 
 [rpc]
 apis = ["web3", "eth", "pubsub", "net", "parity", "parity_set", "parity_pubsub", "personal", "traces", "rpc", "shh", "shh_pubsub"]


### PR DESCRIPTION
Parity's `nat` variable is `any` by default and parity tries to publish self-address. When a local network supports UPnP, it can be trouble.