### PR TITLE
Stake withdrawal test

### DIFF
--- a/scripts/watcher.js
+++ b/scripts/watcher.js
@@ -41,9 +41,11 @@ web3.eth.subscribe('newBlockHeaders', function(error, result){
     const stakingEpoch = await stakingContract.methods.stakingEpoch().call();
     const stakingEpochStartBlock = await stakingContract.methods.stakingEpochStartBlock().call();
     const validatorSetApplyBlock = await validatorSetContract.methods.validatorSetApplyBlock().call();
+    const stakingEpochEndBlock = await stakingContract.methods.stakingEpochEndBlock().call();
     console.log(`stakingEpoch ${stakingEpoch}`);
     console.log(`  startBlock ${stakingEpochStartBlock}`);
     console.log(`  applyBlock ${validatorSetApplyBlock > 0 ? validatorSetApplyBlock : '-'}`);
+    console.log(`  endBlock   ${stakingEpochEndBlock}`);
     console.log('');
 
     const collectionRound = await randomContract.methods.currentCollectRound().call();

--- a/test/0_staking.js
+++ b/test/0_staking.js
@@ -323,13 +323,12 @@ describe('Candidates make stakes on themselves', () => {
         let delegator = delegators[0];
         let candidate = constants.CANDIDATES[2].staking;
 
-        // initial stake on the candidate
         const withdrawAmountBN = (new BN(minStake.toString()));
+        // initial stake on the candidate
         let iStake = await StakingAuRa.instance.methods.stakeAmount(candidate, delegator).call();
         let iStakeBN = new BN(iStake.toString());
-        console.log(`***** Initial stake of delegator ${delegator} on candidate ${candidate} is ${iStakeBN.toString()}`);
 
-        console.log('***** Ordering a withdrawal');
+        console.log(`***** Initial stake of delegator ${delegator} on candidate ${candidate} is ${iStakeBN.toString()}, going to order withdrawal of ${withdrawAmountBN.toString()}`);
         let tx = await sendInStakingWindow(web3, async () => {
             return SnS(web3, {
                 from: delegator,
@@ -339,7 +338,7 @@ describe('Candidates make stakes on themselves', () => {
             });
         });
         pp.tx(tx);
-        expect(tx.status, `Tx to order stake withdrawal failed: ${tx.transactionHash}`).to.equal(true);
+        expect(tx.status, `Tx to order withdrawal failed: ${tx.transactionHash}`).to.equal(true);
 
         await waitForNextStakingEpoch(web3);
         console.log('**** Claiming ordered withdrawal');

--- a/test/0_staking.js
+++ b/test/0_staking.js
@@ -344,46 +344,4 @@ describe('Candidates place stakes on themselves', () => {
                         `initial = ${iStakeBN.toString()}, final = ${fStakeBN.toString()}, withdraw amount = ${minDelegatorStakeBN.toString()}`
                 ).to.be.bignumber.equal(iStakeBN.sub(minDelegatorStakeBN));
     });
-
-    /*
-    it('Delegator withdraws stake', async () => {
-        let delegator = delegators[0];
-        let candidate = constants.CANDIDATES[2].staking;
-
-        // initial stake on the candidate
-        let iStake = await StakingAuRa.instance.methods.stakeAmount(candidate, delegator).call();
-        let iStakeBN = new BN(iStake.toString());
-
-        console.log(`***** Initial stake of delegator ${delegator} on candidate ${candidate} is ${iStakeBN.toString()}, going to order withdrawal of ${minDelegatorStakeBN.toString()}`);
-        let tx = await sendInStakingWindow(web3, async () => {
-            return SnS(web3, {
-                from: delegator,
-                to: StakingAuRa.address,
-                method: StakingAuRa.instance.methods.orderWithdraw(candidate, minDelegatorStakeBN.toString()),
-                gasPrice: '1000000000'
-            });
-        });
-        pp.tx(tx);
-        expect(tx.status, `Tx to order withdrawal failed: ${tx.transactionHash}`).to.equal(true);
-
-        await waitForNextStakingEpoch(web3);
-
-        console.log('**** Claiming ordered withdrawal');
-        let tx2 = await sendInStakingWindow(web3, async () => {
-            return SnS(web3, {
-                from: delegator,
-                to: StakingAuRa.address,
-                method: StakingAuRa.instance.methods.claimOrderedWithdraw(candidate),
-                gasPrice: '1000000000'
-            });
-        });
-        pp.tx(tx2);
-        let fStake = await StakingAuRa.instance.methods.stakeAmount(candidate, delegator).call();
-        let fStakeBN = new BN(fStake.toString());
-
-        expect(fStakeBN, `Candidate\'s (${candidate}) stake didn\'t decrease correctly after delegator (${delegator}) claimed the withdrawal: ` +
-                        `initial = ${iStakeBN.toString()}, final = ${fStakeBN.toString()}, withdraw amount = ${minDelegatorStakeBN.toString()}`
-                ).to.be.bignumber.equal(iStakeBN.sub(minDelegatorStakeBN));
-    });
-    */
 });

--- a/test/2_remove_pool.js
+++ b/test/2_remove_pool.js
@@ -43,7 +43,7 @@ describe('Pool removal and validator set change', () => {
         expect(tx.status, `Failed tx: ${tx.transactionHash}`).to.equal(true);
     });
 
-    it('Validator is not present in the validator set in the next stacking epoch', async () => {
+    it('Validator is not present in the validator set in the next staking epoch', async () => {
         console.log('***** Wait for staking epoch to change');
         let validators = (await waitForValidatorSetChange(web3)).map(v => v.toLowerCase());
         let validatorIndex = validators.indexOf(tiredValidator.mining.toLowerCase());

--- a/utils/waitForNextStakingEpoch.js
+++ b/utils/waitForNextStakingEpoch.js
@@ -1,0 +1,16 @@
+const getContract = require('./getContract');
+
+const RETRY_INTERVAL_MS = 2499;
+
+module.exports = async (web3) => {
+    let StakingAuRa = getContract('StakingAuRa', web3);
+    let latestBlock = await StakingAuRa.instance.methods.stakingEpochEndBlock().call();
+    console.log('**** Waiting for next staking epoch to start (after block ' + latestBlock + ')')
+    while (
+        parseInt(
+            await web3.eth.getBlockNumber()
+        ) <= latestBlock
+    ) {
+        await new Promise(r => setTimeout(r, RETRY_INTERVAL_MS));
+    }
+}


### PR DESCRIPTION
Add a test for stake withdrawal:

1. moved delegator keys generation to `before` section of test suite, so that it's shared across different `it(...)` sections
2. delegator orders a withdrawal of his stakes from one of the candidates, waits for staking epoch to change and then claims his withdraw.
