### PR TITLE
Small refactor of npm tasks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "posdao-contracts"]
 	path = posdao-contracts
-	url = git@github.com:poanetwork/posdao-contracts.git
+  url = https://github.com/poanetwork/posdao-contracts.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "posdao-contracts"]
 	path = posdao-contracts
-  url = https://github.com/poanetwork/posdao-contracts.git
+	url = https://github.com/poanetwork/posdao-contracts.git

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "",
   "scripts": {
     "all": "npm i && npm run get-all-submodules && npm run cleanup && npm run compile-posdao-contracts && npm run make-spec && npm run start-test-setup && npm run test && npm run stop-test-setup",
-    "cleanup": "rm -rf ./build ./parity-data ./accounts && git checkout ./parity-data && git checkout ./accounts",
+    "cleanup": "bash scripts/stop-test-setup && rm -rf ./build ./parity-data ./accounts && git checkout ./parity-data && git checkout ./accounts",
     "get-all-submodules": "git submodule update --init --remote",
     "compile-posdao-contracts": "cd ./posdao-contracts && npm i && npm run compile",
-    "make-spec": ". ./scripts/network-spec && cd ./posdao-contracts && npm i && node ./scripts/make_spec.js",
+    "make-spec": ". ./scripts/network-spec && cd ./posdao-contracts && npm i && node ./scripts/make_spec.js && node ../scripts/addCandidateBalances.js",
     "start-test-setup": "bash scripts/start-test-setup ../parity-ethereum/target/release/parity && (node scripts/watchOrdinaryNode.js &) && node scripts/deploy-staking-token.js",
     "test": "node_modules/.bin/mocha --bail --timeout 1200000 && npm run watcher",
     "stop-test-setup": "bash scripts/stop-test-setup",

--- a/scripts/deploy-staking-token.js
+++ b/scripts/deploy-staking-token.js
@@ -44,7 +44,6 @@ function compileContract() {
 async function main() {
     console.log('**** Check that StakingToken is already deployed in StakingAuRa');
     let existingStakingTokenAddress = await StakingAuRa.instance.methods.erc20TokenContract().call();
-    console.log('***** raw existingStakingTokenAddress = ', existingStakingTokenAddress);
     if (existingStakingTokenAddress
           && existingStakingTokenAddress.toLowerCase() != '0x'
           && existingStakingTokenAddress.toLowerCase() != '0x0000000000000000000000000000000000000000'

--- a/scripts/deploy-staking-token.js
+++ b/scripts/deploy-staking-token.js
@@ -42,6 +42,17 @@ function compileContract() {
 }
 
 async function main() {
+    console.log('**** Check that StakingToken is already deployed in StakingAuRa');
+    let existingStakingTokenAddress = await StakingAuRa.instance.methods.erc20TokenContract().call();
+    console.log('***** raw existingStakingTokenAddress = ', existingStakingTokenAddress);
+    if (existingStakingTokenAddress
+          && existingStakingTokenAddress.toLowerCase() != '0x'
+          && existingStakingTokenAddress.toLowerCase() != '0x0000000000000000000000000000000000000000'
+        ) {
+        console.log('***** StakingToken already deployed at ' + existingStakingTokenAddress + ', skipping deployment');
+        return;
+    }
+
     let compiledContract = compileContract();
     let abi = compiledContract.abi;
     let bytecode = compiledContract.evm.bytecode.object;

--- a/scripts/start-test-setup
+++ b/scripts/start-test-setup
@@ -6,6 +6,6 @@ set -e
 
 PARITY=$1
 for i in $(seq 0 6); do
-    "$PARITY" --config "./config/node${i}.toml" > "./parity-data/node${i}/log" 2>&1 &
+    "$PARITY" --config "./config/node${i}.toml" >> "./parity-data/node${i}/log" 2>&1 &
     node ./scripts/getReservedPeer.js "$i"
 done

--- a/scripts/start-test-setup
+++ b/scripts/start-test-setup
@@ -2,12 +2,10 @@
 
 # Exit on undefined variables.
 set -u
+set -e
 
 PARITY=$1
-NODE=`which node`
-$NODE ./scripts/addCandidateBalances.js
 for i in $(seq 0 6); do
-    rm -rf -- "./parity-data/node$i/chains"
     "$PARITY" --config "./config/node${i}.toml" > "./parity-data/node${i}/log" 2>&1 &
-    "$NODE" ./scripts/getReservedPeer.js "$i"
+    node ./scripts/getReservedPeer.js "$i"
 done


### PR DESCRIPTION
This is a small refactoring of npm tasks which should (hopefully) separate them more clearly and make re-running tests easier:

1. use `https` instead of `git` for cloning posdao contract submodule (closes #49)
**NOTE** that it's best to re-clone posdao-test-setup after this change, because git caches submodule paths somewhere
2. add killing parity processes to `cleanup` task
3. call `addCandidateBalances` (which changes spec) from `make-spec` instead of `start-test-setup`
4. don't remove existing `parity-data` folder in `start-test-setup`, because it's already done in `cleanup`. So if you just want to restart parity nodes you don't ruin existing state.
5. in `start-test-setup` append to existing log instead of overwriting it (`>` -> `>>`). This allows to save log between parity restarts.
6. add a check in `scripts/deploy-staking-token.js` to not re-deploy staking token contract if it's already deployed