### PR TITLE
Rename Parity to Open-ethereum

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To integrate with [Open Ethereum](https://github.com/OpenEthereum/open-ethereum)
 ├── open-ethereum
 ├── posdao-test-setup
 ```
-So there should be two folders on the same level and `posdao-test-setup` will use a binary from the `open-ethereum` folder, namely the binary is assumed to be at `../open-ethereum/target/release/parity` relative to `posdao-test-setup` root.
+So there should be two folders on the same level and `posdao-test-setup` will use a binary from the `open-ethereum` folder, namely the binary is assumed to be at `../open-ethereum/target/release/open-ethereum` relative to `posdao-test-setup` root.
 
 If you want to compile a specific branch/version of `Open Ethereum`, you can clone it directly and build the binary
 ```bash
@@ -38,10 +38,10 @@ To save time, you can download a pre-compiled binary from the [releases page](ht
 $ cd ..
 $ mkdir -p open-ethereum/target/release/
 # an example for macOS binary
-$ curl -SfL 'https://releases.parity.io/ethereum/stable/x86_64-apple-darwin/parity' -o open-ethereum/target/release/parity
-$ chmod +x open-ethereum/target/release/parity
+$ curl -SfL 'https://releases.parity.io/ethereum/stable/x86_64-apple-darwin/parity' -o open-ethereum/target/release/open-ethereum
+$ chmod +x open-ethereum/target/release/open-ethereum
 # check that it works and version is correct (compare the version from the binary with version on the release page)
-$ open-ethereum/target/release/parity --version
+$ open-ethereum/target/release/open-ethereum --version
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "get-all-submodules": "git submodule update --init --remote",
     "compile-posdao-contracts": "cd ./posdao-contracts && npm i && npm run compile",
     "make-spec": ". ./scripts/network-spec && cd ./posdao-contracts && npm i && node ./scripts/make_spec.js && node ../scripts/copy-spec.js",
-    "start-test-setup": "bash scripts/start-test-setup ../open-ethereum/target/release/parity && (node scripts/watchOrdinaryNode.js &) && node scripts/deploy-staking-token.js && (node scripts/watchRandomSeed &) && (node scripts/emitInitiateChange &)",
+    "start-test-setup": "bash scripts/start-test-setup ../open-ethereum/target/release/open-ethereum && (node scripts/watchOrdinaryNode.js &) && node scripts/deploy-staking-token.js && (node scripts/watchRandomSeed &) && (node scripts/emitInitiateChange &)",
     "test": "node_modules/.bin/mocha --bail --timeout 1200000 && npm run watcher",
     "stop-test-setup": "bash scripts/stop-test-setup",
     "watcher": "node scripts/watcher.js"

--- a/scripts/copy-spec.js
+++ b/scripts/copy-spec.js
@@ -44,7 +44,7 @@ async function main() {
   console.log('Step duration will be changed at ', new Date(newStepDurationTimestamp * 1000).toLocaleTimeString('en-US'));
 
   const exec = promisify(require('child_process').exec);
-  const { stdout, stderr } = await exec('../../open-ethereum/target/release/parity --version');
+  const { stdout, stderr } = await exec('../../open-ethereum/target/release/open-ethereum --version');
 
   assert(!stderr);
 


### PR DESCRIPTION
## Motivation

Parity client was renamed to Open-ethereum. And `cargo build --release --features final` generates now `open-ethereum` bundle. Thus, this statement in README is incorrect nowadays:
> So there should be two folders on the same level and posdao-test-setup will use a binary from the open-ethereum folder, namely the binary is assumed to be at ../open-ethereum/target/release/parity