### PR TITLE
TxPriority test fixes

### DIFF
--- a/test/00_tx_priority.js
+++ b/test/00_tx_priority.js
@@ -1323,7 +1323,7 @@ describe('TxPriority tests', () => {
       }]);
       // Will fail on OpenEthereum
       let receipt = results.receipts[0];
-      expect(receipt, `The owner succeeded when using disallowed gas price of ${gasPrice05} wei. Tx hash: ${receipt.transactionHash}`).to.equal(null);
+      expect(receipt, `The owner succeeded when using disallowed gas price of ${gasPrice05} wei. Tx hash: ${receipt ? receipt.transactionHash: ""}`).to.equal(null);
 
       // The owner successfully calls StakingAuRa.setDelegatorMinStake
       // with the allowed gas price equal to MinGasPrice from the config
@@ -1333,7 +1333,8 @@ describe('TxPriority tests', () => {
         params: { from: OWNER, gasPrice: gasPrice1, nonce: ownerNonce++ }
       }]);
       receipt = results.receipts[0];
-      expect(receipt.status, `The owner failed when using allowed gas price of ${gasPrice1} wei. Tx hash: ${receipt.transactionHash}`).to.equal(true);
+      expect(receipt.status, `The owner failed when using allowed gas price of ${gasPrice1} wei. Tx hash: ${receipt ? receipt.transactionHash: ""}`).to.equal(true);
+
 
       // The owner tries to call StakingAuRa.setCandidateMinStake with gas price
       // which is less than the MinGasPrice from TxPriority, but fails
@@ -1345,7 +1346,7 @@ describe('TxPriority tests', () => {
       }]);
       // Will fail on OpenEthereum
       receipt = results.receipts[0];
-      expect(receipt, `The owner succeeded when using disallowed gas price of ${gasPrice1} wei. Tx hash: ${receipt.transactionHash}`).to.equal(null);
+      expect(receipt, `The owner succeeded when using disallowed gas price of ${gasPrice1} wei. Tx hash: ${receipt ? receipt.transactionHash: ""}}`).to.equal(null);
 
       // The owner successfully calls StakingAuRa.setCandidateMinStake
       // with the allowed gas price equal to MinGasPrice from TxPriority
@@ -1355,7 +1356,7 @@ describe('TxPriority tests', () => {
         params: { from: OWNER, gasPrice: gasPrice2, nonce: ownerNonce++ }
       }]);
       receipt = results.receipts[0];
-      expect(receipt.status, `The owner failed when using allowed gas price of ${gasPrice2} wei. Tx hash: ${receipt.transactionHash}`).to.equal(true);
+      expect(receipt.status, `The owner failed when using allowed gas price of ${gasPrice2} wei. Tx hash: ${receipt ? receipt.transactionHash: ""}`).to.equal(true);
 
       // Increase MinGasPrice for StakingAuRa.setDelegatorMinStake
       await applyMinGasPrices('set', [
@@ -1373,7 +1374,7 @@ describe('TxPriority tests', () => {
       }]);
       // Will fail on OpenEthereum
       receipt = results.receipts[0];
-      expect(receipt, `The owner succeeded when using disallowed gas price of ${gasPrice2} wei. Tx hash: ${receipt.transactionHash}`).to.equal(null);
+      expect(receipt, `The owner succeeded when using disallowed gas price of ${gasPrice2} wei. Tx hash: ${receipt ? receipt.transactionHash: ""}`).to.equal(null);
 
       // Remove MinGasPrice rule for StakingAuRa.setDelegatorMinStake
       await applyMinGasPrices('remove', [
@@ -1389,7 +1390,7 @@ describe('TxPriority tests', () => {
         params: { from: OWNER, gasPrice: gasPrice2, nonce: ownerNonce++ }
       }]);
       receipt = results.receipts[0];
-      expect(receipt.status, `The owner failed when using allowed gas price of ${gasPrice2} wei. Tx hash: ${receipt.transactionHash}`).to.equal(true);
+      expect(receipt.status, `The owner failed when using allowed gas price of ${gasPrice2} wei. Tx hash: ${receipt ? receipt.transactionHash: ""}`).to.equal(true);
 
       // The owner tries to call StakingAuRa.setCandidateMinStake with gas price
       // which is less than the MinGasPrice from TxPriority and equal to config's, but fails
@@ -1401,7 +1402,7 @@ describe('TxPriority tests', () => {
       }]);
       // Will fail on OpenEthereum
       receipt = results.receipts[0];
-      expect(receipt, `The owner succeeded when using disallowed gas price of ${gasPrice1} wei. Tx hash: ${receipt.transactionHash}`).to.equal(null);
+      expect(receipt, `The owner succeeded when using disallowed gas price of ${gasPrice1} wei. Tx hash: ${receipt ? receipt.transactionHash: ""}`).to.equal(null);
 
       // Remove MinGasPrice rule for StakingAuRa.setCandidateMinStake
       await applyMinGasPrices('remove', [
@@ -1417,7 +1418,7 @@ describe('TxPriority tests', () => {
         params: { from: OWNER, gasPrice: gasPrice1, nonce: ownerNonce++ }
       }]);
       receipt = results.receipts[0];
-      expect(receipt.status, `The owner failed when using allowed gas price of ${gasPrice1} wei. Tx hash: ${receipt.transactionHash}`).to.equal(true);
+      expect(receipt.status, `The owner failed when using allowed gas price of ${gasPrice1} wei. Tx hash: ${receipt ? receipt.transactionHash: ""}`).to.equal(true);
 
       // Set a new MinGasPrice rule for StakingAuRa.setCandidateMinStake
       await applyMinGasPrices('set', [
@@ -1435,7 +1436,7 @@ describe('TxPriority tests', () => {
       }]);
       // Will fail on OpenEthereum
       receipt = results.receipts[0];
-      expect(receipt, `The owner succeeded when using disallowed gas price of ${gasPrice2} wei. Tx hash: ${receipt.transactionHash}`).to.equal(null);
+      expect(receipt, `The owner succeeded when using disallowed gas price of ${gasPrice2} wei. Tx hash: ${receipt ? receipt.transactionHash: ""}`).to.equal(null);
 
       // Update the existing MinGasPrice rule for StakingAuRa.setCandidateMinStake
       await applyMinGasPrices('set', [
@@ -1451,7 +1452,7 @@ describe('TxPriority tests', () => {
         params: { from: OWNER, gasPrice: gasPrice2, nonce: ownerNonce++ }
       }]);
       receipt = results.receipts[0];
-      expect(receipt.status, `The owner failed when using allowed gas price of ${gasPrice2} wei. Tx hash: ${receipt.transactionHash}`).to.equal(true);
+      expect(receipt.status, `The owner failed when using allowed gas price of ${gasPrice2} wei. Tx hash: ${receipt ? receipt.transactionHash: ""}`).to.equal(true);
     });
 
     it(testName('Clear priority rules'), async function() {
@@ -1586,14 +1587,14 @@ describe('TxPriority tests', () => {
         const fnSignature = rule[1].toLowerCase();
         if (type == 'set') {
           const value = rule[2].toLowerCase();
-          const index = config.priorities.findIndex(p => p.target.toLowerCase() == target && p.fnSignature.toLowerCase() == fnSignature);
+          const index = config.minGasPrices.findIndex(p => p.target.toLowerCase() == target && p.fnSignature.toLowerCase() == fnSignature);
           if (index < 0) {
-            config.priorities.push({ target, fnSignature, value });
+            config.minGasPrices.push({ target, fnSignature, value });
           } else {
-            config.priorities[index] = { target, fnSignature, value };
+            config.minGasPrices[index] = { target, fnSignature, value };
           }
         } else {
-          config.priorities = config.priorities.filter(p => p.target.toLowerCase() != target || p.fnSignature.toLowerCase() != fnSignature);
+          config.minGasPrices = config.minGasPrices.filter(p => p.target.toLowerCase() != target || p.fnSignature.toLowerCase() != fnSignature);
         }
       });
       await saveConfigFile(config);
@@ -1838,6 +1839,7 @@ async function saveConfigFile(config) {
   for (let t = 0; t < attempts; t++) {
     try {
       fs.writeFileSync(configFilepath, JSON.stringify(config, null, 2));
+	  await sleep(1000);
     } catch (e) {
       if (e.code == 'EBUSY') {
         if (t < attempts - 1) {


### PR DESCRIPTION
1. fix txpriority tests for min gas prices
2. fix tx hash message for null receipts
3. Add sleep after changing rule file for node to pick it up and avoid file locking