### PR TITLE
Fix block reward tests post-merge

### DIFF
--- a/config/node0.nethermind.json
+++ b/config/node0.nethermind.json
@@ -39,7 +39,10 @@
   "Merge":
   {
     "Enabled": true,
-    "Variant": "AuRa",
     "TerminalTotalDifficulty": "44236707699722000250238698966129867489020"
+  },
+  "AuRaMerge":
+  {
+    "Enabled": true
   }
 }

--- a/config/node1.nethermind.json
+++ b/config/node1.nethermind.json
@@ -55,7 +55,10 @@
   "Merge":
   {
     "Enabled": true,
-    "Variant": "AuRa",
     "TerminalTotalDifficulty": "44236707699722000250238698966129867489020"
+  },
+  "AuRaMerge":
+  {
+    "Enabled": true
   }
 }

--- a/config/node2.nethermind.json
+++ b/config/node2.nethermind.json
@@ -55,7 +55,10 @@
   "Merge":
   {
     "Enabled": true,
-    "Variant": "AuRa",
     "TerminalTotalDifficulty": "44236707699722000250238698966129867489020"
+  },
+  "AuRaMerge":
+  {
+    "Enabled": true
   }
 }

--- a/config/node3.nethermind.json
+++ b/config/node3.nethermind.json
@@ -55,7 +55,10 @@
   "Merge":
   {
     "Enabled": true,
-    "Variant": "AuRa",
     "TerminalTotalDifficulty": "44236707699722000250238698966129867489020"
+  },
+  "AuRaMerge":
+  {
+    "Enabled": true
   }
 }

--- a/test/00_block_reward.js
+++ b/test/00_block_reward.js
@@ -60,6 +60,8 @@ describe('BlockReward tests', () => {
     console.log('    TTD is reached. Checking BlockReward feature ...');
 
     // Mint one native coin
+    let minGasPrice = await calcMinGasPrice(web3);
+    let gasPrice = minGasPrice.mul(new BN(2));
     const oneCoin = web3.utils.toWei('1', 'ether');
     await SnS(web3, {
       from: OWNER,


### PR DESCRIPTION
Fixes are:
- Update to latest `bc-test-merge` branch which contained new config format for nethermind AuRaMerge plugin
- Fix `gasPrice` variable not being initialized in post-merge block rewards test